### PR TITLE
Bug Fix #34 Null check on colour change selection

### DIFF
--- a/src/com/thunder_cut/graphics/controller/DrawingModeHandler.java
+++ b/src/com/thunder_cut/graphics/controller/DrawingModeHandler.java
@@ -5,15 +5,18 @@
  */
 package com.thunder_cut.graphics.controller;
 
+import com.thunder_cut.graphics.feature.AreaSelector;
 import com.thunder_cut.graphics.feature.Brush;
 import com.thunder_cut.graphics.feature.DrawingFeature;
 import com.thunder_cut.graphics.feature.Eraser;
-import com.thunder_cut.graphics.feature.AreaSelector;
 import com.thunder_cut.graphics.ui.drawing.CanvasPixelInfo;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JColorChooser;
+import javax.swing.JOptionPane;
+import java.awt.Color;
 import java.util.EnumMap;
+
+import static java.util.Objects.nonNull;
 
 public class DrawingModeHandler {
     private DrawingMode selectedDrawingMode;
@@ -31,15 +34,14 @@ public class DrawingModeHandler {
     }
 
     public void drawingModeChanged(DrawingMode mode) {
-        if(mode == DrawingMode.COLOR_CHOOSER) {
-            color = JColorChooser.showDialog(null, "Color", Color.GRAY);
-        }
-        else if(mode == DrawingMode.SIZE_CHOOSER) {
+        if (mode == DrawingMode.COLOR_CHOOSER) {
+            Color selectedColor = JColorChooser.showDialog(null, "Color", Color.GRAY);
+            color = nonNull(selectedColor) ? selectedColor : color;
+        } else if (mode == DrawingMode.SIZE_CHOOSER) {
             int size = Integer.parseInt(JOptionPane.showInputDialog("size"));
             ((Brush) drawingFeatures.get(DrawingMode.BRUSH)).setSize(size);
             ((Eraser) drawingFeatures.get(DrawingMode.ERASER)).setSize(size);
-        }
-        else {
+        } else {
             selectedDrawingMode = mode;
         }
     }


### PR DESCRIPTION
fixes #34 Issue was when cancel button was pressed color was set to null as no colour was selected
This checks if a colour has been selected otherwise will keep the previous used colour